### PR TITLE
[250915] Day30 - 필수과제

### DIFF
--- a/board/day27/src/app/boards/page.tsx
+++ b/board/day27/src/app/boards/page.tsx
@@ -2,16 +2,28 @@
 
 import BoardListBannerPage from "@/commons/layout/banner"
 import BoardsPage from "@/components/board-list/list"
+import Pagination from "@/components/board-list/pagination"
 
+import style from "../../components/board-list/list/style.module.css"
+import { FetchBoardsDocument, FetchBoardsQuery, FetchBoardsQueryVariables } from "@/commons/graphql/graphql"
+import { useQuery } from "@apollo/client"
+import { FETCH_BOARDS_COUNT } from "@/components/board-list/pagination/queries"
+import { FETCH_BOARDS } from "@/components/board-list/list/queries"
 
 
 export default function Boardpage() {
-
+    const { data, refetch } = useQuery(FETCH_BOARDS
+    )
+    const { data: dataCount} = useQuery(FETCH_BOARDS_COUNT)
+    const lastPage = Math.ceil((dataCount?.fetchBoardsCount ?? 10) / 10)
 
     return (
-        <>
-   
-            <BoardsPage />
-        </>
+        <div className={style.page}>
+
+            <div className={style.boards}>
+                <BoardsPage data={data?.fetchBoards}/>
+                <Pagination refetch={refetch} lastPage={lastPage}/>
+            </div>
+        </div>
     )
 }

--- a/board/day27/src/components/board-list/list/index.tsx
+++ b/board/day27/src/components/board-list/list/index.tsx
@@ -10,7 +10,7 @@ import { useState } from 'react';
 
 
 
-export default function BoardsPage() {
+export default function BoardsPage(props) {
     const { data,      showModal,
         handleOk,
         handleCancel,
@@ -19,15 +19,16 @@ export default function BoardsPage() {
          } = useBoardsPage()
 
     return (
-        <div className={style.page}>
-            <div className={style.boards}>
+        <>
+         {/* <div className={style.page}> */}
+            {/* <div className={style.boards}> */}
                 <div className={style.header}>
                     <div className={style.header__number}>번호</div>
                     <div className={style.header__title}>제목</div>
                     <div className={style.header__writer}>작성자</div>
                     <div className={style.header__date}>날짜</div>
                 </div>
-                {data?.fetchBoards.map((el, index) => {
+                {props?.data?.map((el, index) => {
                     return (
                         <a key={el._id} className={style.data} href={`/board/detail/${el._id}`}>
                             <div className={style.data__number}>{index + 1}</div>
@@ -38,7 +39,7 @@ export default function BoardsPage() {
                         </a>
                     )
                 })}
-            </div>
+            {/* </div> */}
             <Modal
                 title="게시글 삭제"
                 // closable={{ 'aria-label': 'Custom Close Button' }}
@@ -48,7 +49,8 @@ export default function BoardsPage() {
             >
                 <p>{saveId}의 게시글을 삭제하시겠습니까?</p>
             </Modal>
-        </div>
+         {/* </div> */}
+        </>
 
 
     )

--- a/board/day27/src/components/board-list/list/queries.ts
+++ b/board/day27/src/components/board-list/list/queries.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const FETCH_BOARDS = gql`
-query fetchBoards{
-  fetchBoards{
+query fetchBoards($page: Int){
+  fetchBoards(page:$page){
   	_id,writer,title,contents,createdAt,updatedAt
   }
 }
@@ -14,3 +14,4 @@ mutation deleteBoard($boardId: ID!){
     
 }
 `
+

--- a/board/day27/src/components/board-list/list/style.module.css
+++ b/board/day27/src/components/board-list/list/style.module.css
@@ -10,7 +10,7 @@
     display: flex;
     flex-direction: column; 
     width: 1280px;
-    height: 720px;
+    height: 750px;
     margin: 40px;
     padding: 24px 48px 24px 48px;
     box-shadow: 2px 2px 10px gray;

--- a/board/day27/src/components/board-list/pagination/hooks.ts
+++ b/board/day27/src/components/board-list/pagination/hooks.ts
@@ -1,0 +1,42 @@
+"uew client"
+
+import { useState } from "react"
+
+
+export default function usePagination(props){
+    // const { data, refetch} = useQuery(FETCH_BOARDS)
+    // const {data: dataCount} = useQuery(FETCH_BOARDS_COUNT)
+    const [startPage, setStartPage] = useState(1)
+
+    // const lastPage = Math.ceil((dataCount?.fetchBoardsCount ?? 10) /10)
+
+    const onClickPage = (event: React.MouseEvent<HTMLButtonElement> ) => {
+        props.refetch({page: Number(event.target.id)})
+    }
+
+    const onClickPrevPage = () => {
+        if(startPage === 1){
+
+        }else{
+        setStartPage(startPage - 10)
+        props.refetch({page: startPage - 10})
+        }
+    }
+
+    const onClickNextPage = () => {
+        console.log("라스트페이지" + props.lastPage)
+        if(startPage + 10 <= props.lastPage){
+        setStartPage(startPage + 10)
+        props.refetch({page: startPage + 10})}
+    }
+
+
+
+
+    return{
+        startPage,
+        onClickPage,
+        onClickPrevPage,
+        onClickNextPage
+    }
+}

--- a/board/day27/src/components/board-list/pagination/hooks.ts
+++ b/board/day27/src/components/board-list/pagination/hooks.ts
@@ -7,10 +7,12 @@ export default function usePagination(props){
     // const { data, refetch} = useQuery(FETCH_BOARDS)
     // const {data: dataCount} = useQuery(FETCH_BOARDS_COUNT)
     const [startPage, setStartPage] = useState(1)
-
+    const [eventButton, setEventButton] = useState(1)
     // const lastPage = Math.ceil((dataCount?.fetchBoardsCount ?? 10) /10)
 
     const onClickPage = (event: React.MouseEvent<HTMLButtonElement> ) => {
+        const pageNumber = Number(event.target.id)
+        setEventButton(pageNumber)
         props.refetch({page: Number(event.target.id)})
     }
 
@@ -37,6 +39,7 @@ export default function usePagination(props){
         startPage,
         onClickPage,
         onClickPrevPage,
-        onClickNextPage
+        onClickNextPage,
+        eventButton
     }
 }

--- a/board/day27/src/components/board-list/pagination/index.tsx
+++ b/board/day27/src/components/board-list/pagination/index.tsx
@@ -1,0 +1,47 @@
+"uew client"
+
+import { gql, useQuery } from "@apollo/client"
+import { useState } from "react"
+import style from "./style.module.css"
+import { FETCH_BOARDS, FETCH_BOARDS_COUNT } from "./queries"
+import { start } from "repl"
+import usePagination from "./hooks"
+
+
+
+export default function Pagination(props){
+    const {        startPage,
+        onClickPage,
+        onClickPrevPage,
+        onClickNextPage} = usePagination(props)
+
+
+
+    return(
+        <div className={style.paginationPage}>
+            {/* {data?.fetchBoards.map((el) => (
+                
+                <div key={el._id}>
+                    <span>{el._id}</span>
+                    <span>{el.writer}</span>
+                    <span>{el.title}</span>
+                </div>
+            ))} */}
+            <button onClick={onClickPrevPage} className={style.prevButton}>이전</button>
+            <div className={style.pagination}>
+            {new Array(10).fill("아무거나").map((el, index)=> {
+                if(index + startPage <= props.lastPage){
+                    return(
+                <button key={index + startPage} onClick={onClickPage} id={String(index + startPage)} className={style.paginationButton} >{index + startPage}</button>
+            )}else{
+                    return``
+                }
+                 
+})}
+            </div>
+
+            <button onClick={onClickNextPage} className={style.nextButton}>다음</button>
+        </div>
+
+    )
+}

--- a/board/day27/src/components/board-list/pagination/index.tsx
+++ b/board/day27/src/components/board-list/pagination/index.tsx
@@ -10,10 +10,13 @@ import usePagination from "./hooks"
 
 
 export default function Pagination(props){
+    
+
     const {        startPage,
         onClickPage,
         onClickPrevPage,
-        onClickNextPage} = usePagination(props)
+        onClickNextPage,
+        eventButton} = usePagination(props)
 
 
 
@@ -32,7 +35,7 @@ export default function Pagination(props){
             {new Array(10).fill("아무거나").map((el, index)=> {
                 if(index + startPage <= props.lastPage){
                     return(
-                <button key={index + startPage} onClick={onClickPage} id={String(index + startPage)} className={style.paginationButton} >{index + startPage}</button>
+                <button key={index + startPage} onClick={onClickPage} id={String(index + startPage)} className={`${style.paginationButton} ${eventButton === index + startPage ? style.eventButton : ""}`}  >{index + startPage}</button>
             )}else{
                     return``
                 }

--- a/board/day27/src/components/board-list/pagination/queries.ts
+++ b/board/day27/src/components/board-list/pagination/queries.ts
@@ -1,0 +1,17 @@
+import { gql } from "@apollo/client"
+
+export const FETCH_BOARDS = gql`
+    query fetchBoards($page: Int){
+        fetchBoards(page: $page) {
+            _id
+            writer
+            title
+            contents
+        }
+    }
+`
+export const FETCH_BOARDS_COUNT = gql`
+    query fetchBoardsCount{
+        fetchBoardsCount
+    }
+`

--- a/board/day27/src/components/board-list/pagination/style.module.css
+++ b/board/day27/src/components/board-list/pagination/style.module.css
@@ -14,3 +14,7 @@
     width: 32px;
     height: 32px;
 }
+
+.eventButton{
+    background-color: red;
+}

--- a/board/day27/src/components/board-list/pagination/style.module.css
+++ b/board/day27/src/components/board-list/pagination/style.module.css
@@ -1,0 +1,16 @@
+
+.paginationPage{
+    display: flex;
+    justify-content: center;
+
+}
+
+.pagination{
+    display: flex;
+    /* gap: px; */
+}
+
+.paginationButton{
+    width: 32px;
+    height: 32px;
+}


### PR DESCRIPTION
# Day 30

## Figma

## **과제 요구 사항**

### **공통**

- [ ]  `day29` 폴더의 코드를 기반으로 `day30` 을 완성해 주세요.

### **게시글 목록**

- [ ]  게시글 목록과 페이지네이션을 **두 개의 컴포넌트로 분리**해 주세요.
    - [ ]  **게시글 목록 컴포넌트**
        - **경로:** `src/components/boards-list/list`
        - 이미 존재하는 컴포넌트입니다.
    - [ ]  **페이지네이션 컴포넌트**
        - **새 파일 경로:** `src/components/boards-list/pagination`
        - 새로 추가해 주세요.

### **게시글 목록 – 페이지네이션**

- [ ]  페이지네이션 컴포넌트를 구현해 주세요.
    - **경로:** `src/components/boards-list/pagination/index.tsx`
    - [ ]  **이전 페이지**와 **다음 페이지** 이동 기능이 정상 작동해야 합니다.
    - [ ]  **마지막 페이지**를 계산하여, 이전/다음 버튼 클릭 시 페이지 한계를 제한해 주세요.
    - [ ]  페이지 번호는 **마지막 페이지까지만** 노출되도록 해 주세요.
    - [ ]  현재 선택된 페이지 번호에 **색상을 적용**하여 사용자가 현재 페이지를 인지할 수 있도록 해 주세요.

### **게시글 목록 – 최종 조립**

- [ ]  게시글 목록 페이지에 두 컴포넌트를 조립해 주세요.
    - **경로:** `src/app/boards/page.tsx`
    - 위에서 만든 **게시글 목록**과 **페이지네이션** 컴포넌트를 불러와서 조립합니다.
    - `state` 를 페이지 단으로 끌어올려 `data`, `refetch`, `lastPage` 등의 **변수 및 함수**를 두 컴포넌트가 적절히 공유할 수 있도록 해 주세요.

### **컴포넌트 리팩토링**

- [ ]  페이지네이션 컴포넌트의 **타입스크립트 적용 및 파일 분리**를 진행해 주세요.
    - 타입 에러로 빨간 밑줄이 생기는 부분을 **타입 정의**로 해결해 주세요.
    - 유지보수를 위해 아래처럼 파일을 분리합니다.
        - hook.ts
        - index.tsx
        - queries.ts
        - styles.ts
        - types.ts