### PR TITLE
[250922] DAY35 트립트립 과제 제출

### DIFF
--- a/maincamp/src/app/myapis/[travel_id]/page.tsx
+++ b/maincamp/src/app/myapis/[travel_id]/page.tsx
@@ -2,7 +2,6 @@
 
 import TravelDetailExpenseList from "@/components/myapis-list/travel-detail/expense-list";
 import TravelDetailExpenseWrite from "@/components/myapis-list/travel-detail/expense-write";
-import TravelDetailExpenseWrtie from "@/components/myapis-list/travel-detail/expense-write";
 import Button from "@/components/ui/button/Button";
 import { useParams } from "next/navigation";
 import { useState } from "react";

--- a/maincamp/src/app/myapis/page.tsx
+++ b/maincamp/src/app/myapis/page.tsx
@@ -1,20 +1,31 @@
 "use client";
 
 import TravelList from "@/components/myapis-list/travel-list";
+import useTravelList from "@/components/myapis-list/travel-list/hook";
 import TravelWrite from "@/components/myapis-list/travel-write";
 import Button from "@/components/ui/button/Button";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function MyapisPage() {
   const [visible, setVisible] = useState(false);
+  const { travels, fetchTravels, onClickTravel } = useTravelList();
+
+  useEffect(() => {
+    fetchTravels();
+  }, []);
 
   return (
     <>
       <Button variant="FormBtn" type="button" onClick={() => setVisible(true)}>
         여행등록하기
       </Button>
-      {visible && <TravelWrite setVisible={setVisible}></TravelWrite>}
-      <TravelList></TravelList>
+      {visible && (
+        <TravelWrite
+          setVisible={setVisible}
+          fetchTravels={fetchTravels}
+        ></TravelWrite>
+      )}
+      <TravelList travels={travels} onClickTravel={onClickTravel}></TravelList>
     </>
   );
 }

--- a/maincamp/src/components/features/boards/boards-write/hook.ts
+++ b/maincamp/src/components/features/boards/boards-write/hook.ts
@@ -121,7 +121,10 @@ export default function useBoardsWrite({ data }: { data?: any }) {
   };
 
   // (3) 파일 업로드 추가
-  const onChangeFile = async (event: ChangeEvent<HTMLInputElement>) => {
+  const onChangeFile = async (
+    event: ChangeEvent<HTMLInputElement>,
+    index: number
+  ) => {
     const { id, files } = event.target;
     if (!files || files.length === 0) return;
 
@@ -137,38 +140,29 @@ export default function useBoardsWrite({ data }: { data?: any }) {
       return;
     }
 
-    const handleSetImageUrl = (index: number, url: string | undefined) => {
-      setImages((prevUrls) => {
-        const NewUrls = [...prevUrls];
-        console.log(NewUrls);
-        NewUrls[index] = url;
-        return NewUrls;
-      });
-      console.log(images);
-    };
-
     const result = await uploadFile({
       variables: {
         file,
       },
     });
 
-    const fileUrl = result.data?.uploadFile.url;
+    console.log(result.data?.uploadFile.url);
 
-    switch (id) {
-      case "0": {
-        handleSetImageUrl(Number(id), fileUrl);
-        break;
-      }
-      case "1": {
-        handleSetImageUrl(Number(id), fileUrl);
-        break;
-      }
-      case "2": {
-        handleSetImageUrl(Number(id), fileUrl);
-        break;
-      }
-    }
+    const fileUrl = result.data?.uploadFile.url;
+    setImages((preUrls) => {
+      const newUrls = [...preUrls];
+      newUrls[index] = fileUrl;
+      return newUrls;
+    });
+  };
+
+  // (4) 파일 삭제 추가
+  const onClickDelete = (index: number) => {
+    setImages((preUrls) => {
+      const newUrls = [...preUrls];
+      newUrls[index] = undefined;
+      return newUrls;
+    });
   };
 
   // 4. 등록하기 버튼
@@ -275,11 +269,12 @@ export default function useBoardsWrite({ data }: { data?: any }) {
     onChangeBoardAddress,
     onChangeYoutubeUrl,
     onChangeFile,
+    onClickDelete,
     onClickCancel,
     isValid,
     onClickUpdate,
     onClickSubmit,
-    images: images,
+    images,
     isModalOpen,
     onToggleModal,
     handleComplete,

--- a/maincamp/src/components/features/boards/boards-write/hook.ts
+++ b/maincamp/src/components/features/boards/boards-write/hook.ts
@@ -1,241 +1,292 @@
-"use client"
+"use client";
 
 import { useMutation } from "@apollo/client";
 import { useParams, useRouter } from "next/navigation";
 import { ChangeEvent, useState } from "react";
 import { ImageUrlArray, IUpdateBoardInput } from "./types";
 import { GraphQLError } from "graphql";
-import { CreateBoardDocument, FetchBoardDocument, UpdateBoardDocument, UploadFileDocument } from "@/commons/graphql/graphql";
+import {
+  CreateBoardDocument,
+  FetchBoardDocument,
+  UpdateBoardDocument,
+  UploadFileDocument,
+} from "@/commons/graphql/graphql";
 import { Modal } from "antd";
 import { Address } from "react-daum-postcode";
 
-export default function useBoardsWrite({data}:{data?: any}){
-    
-        // 0. 세팅
-        const router = useRouter();
-        const params = useParams();
-    
-        /* 게시물 등록 유효성 검사 */
-        // 1. 작성자, 비밀번호, 제목, 컨텐츠 작성 시 setState로 상태 변경
-        const [inputs, setInputs] = useState({
-          writer: data?.fetchBoard.writer ?? "",
-          password: data?.fetchBoard.password ?? "",
-          title: data?.fetchBoard.title ?? "",
-          contents: data?.fetchBoard.contents ?? "",
-        })
-        const [youtubeUrl, setYoutubeUrl] = useState(!data? "" : data.fetchBoard.youtubeUrl)
-        const [zipcode, setZipcode] = useState(!data? "" : data.fetchBoard.boardAddress?.zipcode)
-        const [address, setAddress] = useState(!data? "" : data.fetchBoard.boardAddress?.address)
-        const [addressDetail, setAddressDetail] = useState(!data? "" : data.fetchBoard.boardAddress?.addressDetail)
-        const [images, setImages] = useState<ImageUrlArray>(!data?[undefined, undefined, undefined]:data?.fetchBoard.images )
-        
-        // 1-2. 게시글 생성 API 요청 함수
-        const [createBoard] = useMutation(CreateBoardDocument)
-    
-        // 1-3. 게시글 수정 API 요청 함수
-        const [updateBoard] = useMutation(UpdateBoardDocument)
-    
-        // 1-4. 이미지 업로드 API 요청 함수
-        const [uploadFile] = useMutation(UploadFileDocument);
-    
-    
-        // 2. 필수 작성 요소 작성 여부에 따른 버튼 활성화
-        const [isValid, setIsValid] = useState(true)
-    
-        // 3. Change Event에 따른 유효성 검증
-        const onChangeInputs = (event: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {
-          setInputs({
-            ...inputs,
-            [event.target.id]: event.target.value,
-          })
+export default function useBoardsWrite({ data }: { data?: any }) {
+  // 0. 세팅
+  const router = useRouter();
+  const params = useParams();
 
-          if(inputs.writer && inputs.password && inputs.title && inputs.contents){
-            setIsValid(false)
-          } else{
-            setIsValid(true)
-          }
-        }
-    
-          // 3-1. 필수 요소 아닌 ChangeEvent 추가
-          // (1) YoutubeUrl
-          const onChangeYoutubeUrl = (event: React.ChangeEvent<HTMLInputElement>) => {
-            const value = event.target.value
-            setYoutubeUrl(value)
-          }
+  /* 게시물 등록 유효성 검사 */
+  // 1. 작성자, 비밀번호, 제목, 컨텐츠 작성 시 setState로 상태 변경
+  const [inputs, setInputs] = useState({
+    writer: data?.fetchBoard.writer ?? "",
+    password: data?.fetchBoard.password ?? "",
+    title: data?.fetchBoard.title ?? "",
+    contents: data?.fetchBoard.contents ?? "",
+  });
+  const [youtubeUrl, setYoutubeUrl] = useState(
+    !data ? "" : data.fetchBoard.youtubeUrl
+  );
+  const [zipcode, setZipcode] = useState(
+    !data ? "" : data.fetchBoard.boardAddress?.zipcode
+  );
+  const [address, setAddress] = useState(
+    !data ? "" : data.fetchBoard.boardAddress?.address
+  );
+  const [addressDetail, setAddressDetail] = useState(
+    !data ? "" : data.fetchBoard.boardAddress?.addressDetail
+  );
+  const [images, setImages] = useState<ImageUrlArray>(
+    !data ? [undefined, undefined, undefined] : data?.fetchBoard.images
+  );
 
-          // (2) 주소 입력 API 추가
-          const [isModalOpen, setIsModalOpen] = useState(false);
+  // 1-2. 게시글 생성 API 요청 함수
+  const [createBoard] = useMutation(CreateBoardDocument);
 
-          const onToggleModal = () => {
-            // console.log(isModalOpen)
-            setIsModalOpen((prev) => !prev)
-          }
+  // 1-3. 게시글 수정 API 요청 함수
+  const [updateBoard] = useMutation(UpdateBoardDocument);
 
-          const onChangeBoardAddress = (event: React.ChangeEvent<HTMLInputElement>) => {
-            const {id, value} = event.target;
-            switch(id){
-              case "zipcode": {setZipcode(value);break;}
-              case "address": {setAddress(value);break;}
-              case "addressDetail": {setAddressDetail(value);break;}
-            }
-          }
+  // 1-4. 이미지 업로드 API 요청 함수
+  const [uploadFile] = useMutation(UploadFileDocument);
 
-          const boardAddress = {zipcode: zipcode, address: address, addressDetail: addressDetail}
+  // 2. 필수 작성 요소 작성 여부에 따른 버튼 활성화
+  const [isValid, setIsValid] = useState(true);
 
-          const handleComplete = (data: Address) => {
-            console.log(data); // e.g. '서울 성동구 왕십리로2길 20 (성수동1가)'
-            setZipcode(data.zonecode)
-            setAddress(data.address)
-            setAddressDetail(data.buildingName)
-            onToggleModal();
-          };
-          
-          // (3) 파일 업로드 추가
-          const onChangeFile = async(event: ChangeEvent<HTMLInputElement>) => {
-            const {id, files} = event.target;
-            const file = files?.[0];
-    
-            const handleSetImageUrl = (index: number, url: string|undefined) => {
-              setImages(
-                prevUrls => {
-                  const NewUrls = [...prevUrls]
-                  console.log(NewUrls)
-                  NewUrls[index] = url
-                  return NewUrls
-                }
-              )
-              console.log(images)
-            }
-            
-            const result = await uploadFile({
-              variables:{
-                file
-              }
-            }
-          );
-    
-            const fileUrl = result.data?.uploadFile.url
-    
-            switch(id){
-              case "0":{handleSetImageUrl(Number(id), fileUrl);break;}
-              case "1":{handleSetImageUrl(Number(id), fileUrl);break;}
-              case "2":{handleSetImageUrl(Number(id), fileUrl);break;}
-            }
-            
-          }
-    
-          // 4. 등록하기 버튼
-          const onClickSubmit = async () => {
-            try{
-              const result = await createBoard({
-                variables:{
-                  createBoardInput:{
-                    writer: inputs.writer,
-                    password: inputs.password,
-                    title: inputs.title,
-                    contents: inputs.contents,
-                    youtubeUrl: youtubeUrl,
-                    boardAddress: {
-                      zipcode: zipcode,
-                      address: address,
-                      addressDetail: addressDetail,
-                    },
-                    images: images.filter(Boolean) as string[],
-                  }
-                }
-              })
-              console.log("🚀 ~ onClickBtn ~ result:", result)
-              const boardId = result.data?.createBoard._id
-              router.push(
-                `/boards/${boardId}`
-              )
-    
-            } catch (error) {
-              const showErrorModal = () => Modal.error({
-                title: '에러가 발생하였습니다.',
-                content: error as string ?? "에러가 발생하였습니다",
-              });
-              showErrorModal()
-            } 
-          }
-    
-          // 5. 수정하기 버튼
-          // 수정 버튼 클릭 시 updateBoard 진행
-          const onClickUpdate = async() => {
-                  // 5-1. 수정된 사항만 업데이트 될 수 있도록 variables 설정
-          const updateBoardInput: IUpdateBoardInput ={}
-          if (inputs.title!==data.fetchBoard.title && inputs.title.length>0) updateBoardInput.title = inputs.title;
-          if (inputs.contents!==data.fetchBoard.contents && inputs.contents.length>0) updateBoardInput.contents = inputs.contents;
-          if (youtubeUrl!==data.fetchBoard.youtubeUrl) updateBoardInput.youtubeUrl = youtubeUrl;
-          if (boardAddress!==data.fetchBoard.boardAddress){
-            updateBoardInput.boardAddress = {
-                zipcode: zipcode,
-                address: address,
-                addressDetail: addressDetail
-            };
-          }
-          if (images.filter(Boolean)) {
-            updateBoardInput.images = images.filter(Boolean) as string[];
-            console.log(updateBoardInput)
-          }
-          console.log(updateBoardInput)
-          console.log(params.boardId);
-          
-            try{
-              const password = prompt("글을 입력할때 입력하셨던 비밀번호를 입력해주세요")
-              console.log(password);
-              
-              const result = await updateBoard({
-                variables: {
-                  updateBoardInput,
-                  password,
-                  boardId: params.boardId as string,
-                },
-                refetchQueries: [
-                  {
-                    query: FetchBoardDocument,
-                    variables: { boardId: params.boardId }
-                  },
-                ]
-              })
-              console.log(result)
-              router.push(
-                `/boards/${result.data?.updateBoard._id}`
-              )
-            } catch (error) {
-              const err = error as GraphQLError
-              const showErrorModal = () => Modal.error({
-                title: '에러가 발생하였습니다.',
-                content: err.message as string ?? "에러가 발생하였습니다",
-              });
-              showErrorModal()
-            }
-            
-          }
-    
-          // 6. 취소 버튼 클릭 시 뒤로 가기
-          const onClickCancel = () => {
-            router.back()
-          }
-    
-    return{
-        inputs,
-        onChangeInputs,
-        onChangeBoardAddress,
-        onChangeYoutubeUrl,
-        onChangeFile,
-        onClickCancel,
-        isValid,
-        onClickUpdate,
-        onClickSubmit,
-        images: images,
-        isModalOpen,
-        onToggleModal,
-        handleComplete,
-        setZipcode,
-        setAddress,
-        setAddressDetail,
-        boardAddress,
-        youtubeUrl,
+  // 3. Change Event에 따른 유효성 검증
+  const onChangeInputs = (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    setInputs({
+      ...inputs,
+      [event.target.id]: event.target.value,
+    });
+
+    if (inputs.writer && inputs.password && inputs.title && inputs.contents) {
+      setIsValid(false);
+    } else {
+      setIsValid(true);
     }
+  };
+
+  // 3-1. 필수 요소 아닌 ChangeEvent 추가
+  // (1) YoutubeUrl
+  const onChangeYoutubeUrl = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setYoutubeUrl(value);
+  };
+
+  // (2) 주소 입력 API 추가
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const onToggleModal = () => {
+    // console.log(isModalOpen)
+    setIsModalOpen((prev) => !prev);
+  };
+
+  const onChangeBoardAddress = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = event.target;
+    switch (id) {
+      case "zipcode": {
+        setZipcode(value);
+        break;
+      }
+      case "address": {
+        setAddress(value);
+        break;
+      }
+      case "addressDetail": {
+        setAddressDetail(value);
+        break;
+      }
+    }
+  };
+
+  const boardAddress = {
+    zipcode: zipcode,
+    address: address,
+    addressDetail: addressDetail,
+  };
+
+  const handleComplete = (data: Address) => {
+    console.log(data); // e.g. '서울 성동구 왕십리로2길 20 (성수동1가)'
+    setZipcode(data.zonecode);
+    setAddress(data.address);
+    setAddressDetail(data.buildingName);
+    onToggleModal();
+  };
+
+  // (3) 파일 업로드 추가
+  const onChangeFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const { id, files } = event.target;
+    if (!files || files.length === 0) return;
+
+    const file = files?.[0];
+
+    if (file.size > 5 * 1024 * 1024) {
+      const showErrorModal = () =>
+        Modal.error({
+          title: "파일 업로드에 실패하였습니다",
+          content: "업로드 가능한 용량(5MB)을 초과하였습니다.",
+        });
+      showErrorModal();
+      return;
+    }
+
+    const handleSetImageUrl = (index: number, url: string | undefined) => {
+      setImages((prevUrls) => {
+        const NewUrls = [...prevUrls];
+        console.log(NewUrls);
+        NewUrls[index] = url;
+        return NewUrls;
+      });
+      console.log(images);
+    };
+
+    const result = await uploadFile({
+      variables: {
+        file,
+      },
+    });
+
+    const fileUrl = result.data?.uploadFile.url;
+
+    switch (id) {
+      case "0": {
+        handleSetImageUrl(Number(id), fileUrl);
+        break;
+      }
+      case "1": {
+        handleSetImageUrl(Number(id), fileUrl);
+        break;
+      }
+      case "2": {
+        handleSetImageUrl(Number(id), fileUrl);
+        break;
+      }
+    }
+  };
+
+  // 4. 등록하기 버튼
+  const onClickSubmit = async () => {
+    try {
+      const result = await createBoard({
+        variables: {
+          createBoardInput: {
+            writer: inputs.writer,
+            password: inputs.password,
+            title: inputs.title,
+            contents: inputs.contents,
+            youtubeUrl: youtubeUrl,
+            boardAddress: {
+              zipcode: zipcode,
+              address: address,
+              addressDetail: addressDetail,
+            },
+            images: images.filter(Boolean) as string[],
+          },
+        },
+      });
+      console.log("🚀 ~ onClickBtn ~ result:", result);
+      const boardId = result.data?.createBoard._id;
+      router.push(`/boards/${boardId}`);
+    } catch (error) {
+      const showErrorModal = () =>
+        Modal.error({
+          title: "에러가 발생하였습니다.",
+          content: (error as string) ?? "에러가 발생하였습니다",
+        });
+      showErrorModal();
+    }
+  };
+
+  // 5. 수정하기 버튼
+  // 수정 버튼 클릭 시 updateBoard 진행
+  const onClickUpdate = async () => {
+    // 5-1. 수정된 사항만 업데이트 될 수 있도록 variables 설정
+    const updateBoardInput: IUpdateBoardInput = {};
+    if (inputs.title !== data.fetchBoard.title && inputs.title.length > 0)
+      updateBoardInput.title = inputs.title;
+    if (
+      inputs.contents !== data.fetchBoard.contents &&
+      inputs.contents.length > 0
+    )
+      updateBoardInput.contents = inputs.contents;
+    if (youtubeUrl !== data.fetchBoard.youtubeUrl)
+      updateBoardInput.youtubeUrl = youtubeUrl;
+    if (boardAddress !== data.fetchBoard.boardAddress) {
+      updateBoardInput.boardAddress = {
+        zipcode: zipcode,
+        address: address,
+        addressDetail: addressDetail,
+      };
+    }
+    if (images.filter(Boolean)) {
+      updateBoardInput.images = images.filter(Boolean) as string[];
+      console.log(updateBoardInput);
+    }
+    console.log(updateBoardInput);
+    console.log(params.boardId);
+
+    try {
+      const password = prompt(
+        "글을 입력할때 입력하셨던 비밀번호를 입력해주세요"
+      );
+      console.log(password);
+
+      const result = await updateBoard({
+        variables: {
+          updateBoardInput,
+          password,
+          boardId: params.boardId as string,
+        },
+        refetchQueries: [
+          {
+            query: FetchBoardDocument,
+            variables: { boardId: params.boardId },
+          },
+        ],
+      });
+      console.log(result);
+      router.push(`/boards/${result.data?.updateBoard._id}`);
+    } catch (error) {
+      const err = error as GraphQLError;
+      const showErrorModal = () =>
+        Modal.error({
+          title: "에러가 발생하였습니다.",
+          content: (err.message as string) ?? "에러가 발생하였습니다",
+        });
+      showErrorModal();
+    }
+  };
+
+  // 6. 취소 버튼 클릭 시 뒤로 가기
+  const onClickCancel = () => {
+    router.back();
+  };
+
+  return {
+    inputs,
+    onChangeInputs,
+    onChangeBoardAddress,
+    onChangeYoutubeUrl,
+    onChangeFile,
+    onClickCancel,
+    isValid,
+    onClickUpdate,
+    onClickSubmit,
+    images: images,
+    isModalOpen,
+    onToggleModal,
+    handleComplete,
+    setZipcode,
+    setAddress,
+    setAddressDetail,
+    boardAddress,
+    youtubeUrl,
+  };
 }

--- a/maincamp/src/components/features/boards/boards-write/index.tsx
+++ b/maincamp/src/components/features/boards/boards-write/index.tsx
@@ -1,77 +1,143 @@
-"use client"
+"use client";
 
-import Button from '@/components/ui/button/Button'
-import { Inputfield, Textareafield } from '@/components/ui/input/Inputfield'
-import InputBoardAddress from '@/components/ui/input/InputBoardAddress'
-import InputImage from '@/components/ui/input/InputImage'
-import styles from './style.module.css'
-import useBoardsWrite from './hook'
+import Button from "@/components/ui/button/Button";
+import { Inputfield, Textareafield } from "@/components/ui/input/Inputfield";
+import InputBoardAddress from "@/components/ui/input/InputBoardAddress";
+import InputImage from "@/components/ui/input/InputImage";
+import styles from "./style.module.css";
+import useBoardsWrite from "./hook";
 import { Modal } from "antd";
 import DaumPostcodeEmbed from "react-daum-postcode";
-import { Board } from '@/commons/graphql/graphql'
+import { Board } from "@/commons/graphql/graphql";
+import UploadImages from "./uploadImages/uploadImages";
 
+export default function BoardsWrite({
+  isEdit,
+  data,
+}: {
+  isEdit: boolean;
+  data?: { fetchBoard: Board };
+}) {
+  const {
+    inputs,
+    onChangeInputs,
+    onChangeBoardAddress,
+    onChangeYoutubeUrl,
+    onClickCancel,
+    onClickUpdate,
+    onClickSubmit,
+    onChangeFile,
+    onClickDelete,
+    isValid,
+    images,
+    isModalOpen,
+    onToggleModal,
+    handleComplete,
+    boardAddress,
+    youtubeUrl,
+  } = useBoardsWrite({ data });
 
-
-
-export default function BoardsWrite({isEdit, data}:{isEdit: boolean, data?:{fetchBoard: Board}}){
-
-    const { 
-        inputs,
-        onChangeInputs,
-        onChangeBoardAddress, 
-        onChangeYoutubeUrl, 
-        onClickCancel, 
-        onClickUpdate, 
-        onClickSubmit, 
-        onChangeFile, 
-        isValid, 
-        images,
-        isModalOpen,
-        onToggleModal,
-        handleComplete,
-        boardAddress,
-        youtubeUrl
-    } = useBoardsWrite({data});
-
-    return(
-        <div className={styles.Formfield}>
-            {/* 폼 타이틀 */}
-            <div className={styles.postForm__title}>게시물 {isEdit? "수정":"등록"}</div>
-            {/* 작성자 그룹 */}
-            <div className={styles.postForm__writer__group}>
-                <Inputfield type='text' label='작성자' required placeholder='작성자 명을 입력해 주세요.' id="writer" value={inputs?.writer} isEdit={isEdit} onChange={onChangeInputs}></Inputfield>
-                <Inputfield type='password' label='비밀번호' required placeholder='비밀번호를 입력해 주세요.' id="password" value={inputs?.password} isEdit={isEdit} onChange={onChangeInputs}></Inputfield>
-            </div>
-            <hr />
-            <Inputfield type='text' label='제목'required placeholder='제목을 입력해 주세요.' id="title" value={inputs?.title} onChange={onChangeInputs} ></Inputfield>
-            <hr/>
-            <Textareafield label='내용' required placeholder='내용을 입력해 주세요.' id="contents" value={inputs?.contents} onChange={onChangeInputs} ></Textareafield>
-            <hr />
-            <InputBoardAddress placeholder='주소를 입력해 주세요.' placeholder_2='상세주소' isEdit={isEdit} value={boardAddress} onClick={onToggleModal} onChange={onChangeBoardAddress}></InputBoardAddress>
-            {isModalOpen && 
-                <Modal 
-                    title="주소입력하기" 
-                    open={true}
-                    styles={{body:{height: 450}}}
-                    onOk={onToggleModal}
-                    onCancel={onToggleModal}>
-                    <DaumPostcodeEmbed onComplete={handleComplete} style={{ height: "100%"}}/>
-                </Modal>}
-            <hr />
-            <Inputfield type='string' label='유튜브 링크' placeholder='링크를 입력해 주세요.' value={youtubeUrl} onChange={onChangeYoutubeUrl}></Inputfield>
-            <hr />
-            <div className={styles.postForm__attachments__group}>
-                <label>사진 첨부</label>
-                <div className={styles.image__upload__group}>
-                    {images[0] ? <img src={`https://storage.googleapis.com/${images[0]}`} className={styles.upload__image}/>:<InputImage id="0" onChange={onChangeFile} className={styles.upload__image}/>}
-                    {images[1] ? <img src={`https://storage.googleapis.com/${images[1]}`} className={styles.upload__image}/>:<InputImage id="1" onChange={onChangeFile} className={styles.upload__image}/>}
-                    {images[2] ? <img src={`https://storage.googleapis.com/${images[2]}`} className={styles.upload__image}/>:<InputImage id="2" onChange={onChangeFile} className={styles.upload__image}/>}
-                </div>
-            </div>
-            <div className={styles.postForm__button__group}>
-                <Button type="button" variant='FormBtn' onClick={onClickCancel}>취소</Button>
-                <Button type="submit" variant='FormBtn' disabled={isEdit? false :isValid} onClick={isEdit? onClickUpdate :onClickSubmit}>{isEdit? "수정" : "등록"}하기</Button>
-            </div>
-        </div>
-    );
+  return (
+    <div className={styles.Formfield}>
+      {/* 폼 타이틀 */}
+      <div className={styles.postForm__title}>
+        게시물 {isEdit ? "수정" : "등록"}
+      </div>
+      {/* 작성자 그룹 */}
+      <div className={styles.postForm__writer__group}>
+        <Inputfield
+          type="text"
+          label="작성자"
+          required
+          placeholder="작성자 명을 입력해 주세요."
+          id="writer"
+          value={inputs?.writer}
+          isEdit={isEdit}
+          onChange={onChangeInputs}
+        ></Inputfield>
+        <Inputfield
+          type="password"
+          label="비밀번호"
+          required
+          placeholder="비밀번호를 입력해 주세요."
+          id="password"
+          value={inputs?.password}
+          isEdit={isEdit}
+          onChange={onChangeInputs}
+        ></Inputfield>
+      </div>
+      <hr />
+      <Inputfield
+        type="text"
+        label="제목"
+        required
+        placeholder="제목을 입력해 주세요."
+        id="title"
+        value={inputs?.title}
+        onChange={onChangeInputs}
+      ></Inputfield>
+      <hr />
+      <Textareafield
+        label="내용"
+        required
+        placeholder="내용을 입력해 주세요."
+        id="contents"
+        value={inputs?.contents}
+        onChange={onChangeInputs}
+      ></Textareafield>
+      <hr />
+      <InputBoardAddress
+        placeholder="주소를 입력해 주세요."
+        placeholder_2="상세주소"
+        isEdit={isEdit}
+        value={boardAddress}
+        onClick={onToggleModal}
+        onChange={onChangeBoardAddress}
+      ></InputBoardAddress>
+      {isModalOpen && (
+        <Modal
+          title="주소입력하기"
+          open={true}
+          styles={{ body: { height: 450 } }}
+          onOk={onToggleModal}
+          onCancel={onToggleModal}
+        >
+          <DaumPostcodeEmbed
+            onComplete={handleComplete}
+            style={{ height: "100%" }}
+          />
+        </Modal>
+      )}
+      <hr />
+      <Inputfield
+        type="string"
+        label="유튜브 링크"
+        placeholder="링크를 입력해 주세요."
+        value={youtubeUrl}
+        onChange={onChangeYoutubeUrl}
+      ></Inputfield>
+      <hr />
+      <div className={styles.postForm__attachments__group}>
+        <label>사진 첨부</label>
+        <UploadImages
+          images={images}
+          onClickDelete={onClickDelete}
+          onChangeFile={onChangeFile}
+        />
+      </div>
+      <div className={styles.postForm__button__group}>
+        <Button type="button" variant="FormBtn" onClick={onClickCancel}>
+          취소
+        </Button>
+        <Button
+          type="submit"
+          variant="FormBtn"
+          disabled={isEdit ? false : isValid}
+          onClick={isEdit ? onClickUpdate : onClickSubmit}
+        >
+          {isEdit ? "수정" : "등록"}하기
+        </Button>
+      </div>
+    </div>
+  );
 }

--- a/maincamp/src/components/features/boards/boards-write/style.module.css
+++ b/maincamp/src/components/features/boards/boards-write/style.module.css
@@ -1,103 +1,85 @@
-.Formfield{
+.Formfield {
+  max-width: 80rem;
+  width: 100%;
+
+  padding: 2.5rem 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.Formfield hr {
+  height: 0;
+  border: none;
+  border-top: 0.0625rem solid var(--color-gray-100);
+}
+
+.postForm__title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+.Formfield input {
+  margin-top: 0.5rem;
+}
+
+.postForm__writer__group {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 2.5rem;
+}
+
+.postForm__writer__group div {
+  flex: 1 0 0;
+}
+
+.postForm__button__group {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+@media (max-width: 1280px) {
+  .Formfield {
     max-width: 80rem;
+    min-width: 46.3125rem;
     width: 100%;
 
-    padding: 2.5rem 0;
-
-    display: flex;
-    flex-direction: column;
-    gap: 2.5rem;
+    padding: 2.5rem 1.25rem;
+  }
 }
 
+@media (max-width: 780px) {
+  .Formfield {
+    max-width: 46.3125rem;
+    min-width: 20rem;
+    width: 100%;
 
-.Formfield hr{
-    height: 0;
-    border: none;
-    border-top: 0.0625rem solid var(--color-gray-100);
-}
+    /* padding: 1.5rem 1.25rem; */
+    /* min-width: 20rem; */
+  }
 
-.postForm__title{
-    font-size: var(--font-size-lg);
-    font-weight: var(--font-weight-bold);
-}
-
-.Formfield input{
-    margin-top: 0.5rem;
-}
-
-.postForm__writer__group{
+  .postForm__button__group {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
-    gap: 2.5rem;
-}
+    justify-content: center;
+  }
 
-.postForm__writer__group div{
+  .postForm__button__group button {
     flex: 1 0 0;
-}
+    justify-content: center;
+  }
 
-.image__upload__group{
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    margin-top: 0.5rem;
-}
-
-.upload__image{
+  .upload__image {
     max-width: 10rem;
-    min-width: 10rem;
+    min-width: 6.25rem;
     width: 100%;
-    height: 10rem;
-    border-radius:  0.5rem;
+  }
 
-    object-fit: cover;
-}
-
-.postForm__button__group{
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    gap: 1rem;
-}
-
-@media (max-width: 1280px){
-    .Formfield{
-        max-width: 80rem;
-        min-width: 46.3125rem;
-        width: 100%;
-
-        padding: 2.5rem 1.25rem;
-    }
-}
-
-@media (max-width: 780px){
-    .Formfield{
-        max-width: 46.3125rem;
-        min-width: 20rem;
-        width: 100%;
-
-        /* padding: 1.5rem 1.25rem; */
-        /* min-width: 20rem; */
-    }
-
-    .postForm__button__group{
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-    }
-
-    .postForm__button__group button{
-        flex: 1 0 0;
-        justify-content: center;
-    }
-
-    .upload__image{
-        max-width: 10rem;
-        min-width: 6.25rem;
-        width: 100%;
-    }
-
-    .image__upload__group{
-        flex: 1 1 0;
-    }
+  .image__upload__group {
+    flex: 1 1 0;
+  }
 }

--- a/maincamp/src/components/features/boards/boards-write/uploadImages/styles.module.css
+++ b/maincamp/src/components/features/boards/boards-write/uploadImages/styles.module.css
@@ -1,0 +1,88 @@
+.image__upload__group {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.image__upload__group div {
+  position: relative;
+}
+
+.upload__image {
+  max-width: 10rem;
+  min-width: 10rem;
+  width: 100%;
+  height: 10rem;
+  border-radius: 0.5rem;
+
+  object-fit: cover;
+}
+
+.imageDeleteBtn {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+
+  display: none;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+}
+
+.image__label:hover .imageDeleteBtn {
+  display: flex;
+}
+
+.add__image label {
+  width: 10rem;
+  height: 10rem;
+  border-radius: 0.5rem;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+
+  background-color: var(--color-gray-50);
+
+  color: var(--color-gray-600);
+}
+
+.add__image img {
+  fill: var(--color-gray-600);
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.add__image span {
+  color: var(--color-gray-600);
+}
+
+.textDesktop {
+  display: inline;
+}
+
+.textMobile {
+  display: none;
+}
+
+@media (max-width: 780px) {
+  .add__image label {
+    max-width: 10rem;
+    min-width: 6.25rem;
+    width: 100%;
+    flex: 1 1 0;
+  }
+  .textDesktop {
+    display: none;
+  }
+  .textMobile {
+    display: inline;
+  }
+}

--- a/maincamp/src/components/features/boards/boards-write/uploadImages/uploadImages.tsx
+++ b/maincamp/src/components/features/boards/boards-write/uploadImages/uploadImages.tsx
@@ -1,0 +1,75 @@
+import InputImage from "@/components/ui/input/InputImage";
+import styles from "./styles.module.css";
+import classNames from "classnames";
+
+interface IUploadImages {
+  images: (string | null | undefined)[];
+  onClickDelete: (index: number) => void;
+  onChangeFile: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    index: number
+  ) => Promise<void>;
+}
+
+export default function UploadImages({
+  images,
+  onClickDelete,
+  onChangeFile,
+}: IUploadImages) {
+  const fixedImages = [...images, "", "", ""].slice(0, 3);
+  return (
+    <div className={styles.image__upload__group}>
+      {fixedImages?.map((image, index) => (
+        <div key={`${index}-${image}`}>
+          <input
+            id={`${index}-${image}`}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={(e) => onChangeFile(e, index)}
+          />
+          {image ? (
+            // 이미지 있을 때 이미지 미리보기
+            <label
+              htmlFor={`${index}-${image}`}
+              className={styles.image__label}
+            >
+              <img
+                src={`https://storage.googleapis.com/${image}`}
+                className={styles.upload__image}
+              />
+              <button
+                className={styles.imageDeleteBtn}
+                onClick={() => onClickDelete(index)}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                >
+                  <path
+                    d="M8.00001 8.70153L4.61801 12.0837C4.52567 12.1759 4.40962 12.2231 4.26984 12.2254C4.13017 12.2275 4.01201 12.1803 3.91534 12.0837C3.81879 11.987 3.77051 11.8699 3.77051 11.7324C3.77051 11.5948 3.81879 11.4777 3.91534 11.381L7.29751 7.99903L3.91534 4.61703C3.82312 4.5247 3.7759 4.40864 3.77367 4.26886C3.77156 4.1292 3.81879 4.01103 3.91534 3.91436C4.01201 3.81781 4.12912 3.76953 4.26667 3.76953C4.40423 3.76953 4.52134 3.81781 4.61801 3.91436L8.00001 7.29653L11.382 3.91436C11.4743 3.82214 11.5904 3.77492 11.7302 3.7727C11.8698 3.77059 11.988 3.81781 12.0847 3.91436C12.1812 4.01103 12.2295 4.12814 12.2295 4.2657C12.2295 4.40325 12.1812 4.52037 12.0847 4.61703L8.70251 7.99903L12.0847 11.381C12.1769 11.4734 12.2241 11.5894 12.2263 11.7292C12.2285 11.8689 12.1812 11.987 12.0847 12.0837C11.988 12.1803 11.8709 12.2285 11.7333 12.2285C11.5958 12.2285 11.4787 12.1803 11.382 12.0837L8.00001 8.70153Z"
+                    fill="white"
+                  />
+                </svg>
+              </button>
+            </label>
+          ) : (
+            // 이미지 없을 때 미리보기
+            <div
+              className={classNames(styles.upload__image, styles.add__image)}
+            >
+              <label htmlFor={`${index}-${image}`}>
+                <img src={"/icons/add.svg"} />
+                <span className={styles.textDesktop}>클릭해서 사진 업로드</span>
+                <span className={styles.textMobile}>사진 업로드</span>
+              </label>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/maincamp/src/components/myapis-list/travel-detail/expense-list/index.tsx
+++ b/maincamp/src/components/myapis-list/travel-detail/expense-list/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useParams } from "next/navigation";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { supabase } from "@/commons/libraries/supabase";
 import styles from "./styles.module.css";
 import {
@@ -15,7 +14,6 @@ import {
   BsCupHotFill,
   BsFillBinocularsFill,
 } from "react-icons/bs";
-import useTravelDetailExpense from "./hook";
 
 export interface TravelExpense {
   expense_id: string;

--- a/maincamp/src/components/myapis-list/travel-list/hook.ts
+++ b/maincamp/src/components/myapis-list/travel-list/hook.ts
@@ -1,8 +1,18 @@
 import { supabase } from "@/commons/libraries/supabase";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+export interface ITravels {
+  travel_id: string;
+  destination: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+}
+
 export default function useTravelList() {
-  const [travels, setTravels] = useState<any[]>([]);
+  const router = useRouter();
+  const [travels, setTravels] = useState<ITravels[]>([]);
 
   const fetchTravels = async () => {
     const { data, error } = await supabase.from("travel_list").select("*");
@@ -10,5 +20,10 @@ export default function useTravelList() {
     setTravels(data ?? []);
   };
 
-  return { travels };
+  const onClickTravel = (event: React.MouseEvent<HTMLDivElement>) => {
+    const travel_id = event.currentTarget.id;
+    router.push(`/myapis/${travel_id}`);
+  };
+
+  return { travels, fetchTravels, onClickTravel };
 }

--- a/maincamp/src/components/myapis-list/travel-list/index.tsx
+++ b/maincamp/src/components/myapis-list/travel-list/index.tsx
@@ -1,28 +1,12 @@
-"use client";
+import { ITravels } from "./hook";
 
-import { supabase } from "@/commons/libraries/supabase";
-import Button from "@/components/ui/button/Button";
-import useTravelList from "./hook";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-
-export default function TravelList() {
-  const router = useRouter();
-  const [travels, setTravels] = useState<any[]>([]);
-
-  const fetchTravels = async () => {
-    const { data, error } = await supabase.from("travel_list").select("*");
-    if (error) return;
-    setTravels(data ?? []);
-  };
-
-  fetchTravels();
-
-  const onClickTravel = (event: React.MouseEvent<HTMLDivElement>) => {
-    const travelId = event.currentTarget.id;
-    router.push(`/myapis/${travelId}`);
-  };
-
+export default function TravelList({
+  travels,
+  onClickTravel,
+}: {
+  travels: ITravels[];
+  onClickTravel: (event: React.MouseEvent<HTMLDivElement>) => void;
+}) {
   return (
     <>
       {travels?.map((el, index) => {

--- a/maincamp/src/components/myapis-list/travel-write/hook.ts
+++ b/maincamp/src/components/myapis-list/travel-write/hook.ts
@@ -3,7 +3,11 @@
 import { supabase } from "@/commons/libraries/supabase";
 import { useState } from "react";
 
-export default function useTravelWrite() {
+export default function useTravelWrite({
+  fetchTravels,
+}: {
+  fetchTravels: () => Promise<void>;
+}) {
   // input state 관리 및 유효성 검사
   const [inputs, setInputs] = useState({
     destination: "",
@@ -50,6 +54,7 @@ export default function useTravelWrite() {
       endDate: "",
     });
     setIsValid(false);
+    fetchTravels();
   };
 
   return { inputs, onChangeInputs, onClickSubmit, isValid };

--- a/maincamp/src/components/myapis-list/travel-write/index.tsx
+++ b/maincamp/src/components/myapis-list/travel-write/index.tsx
@@ -7,10 +7,13 @@ import useTravelWrite from "./hook";
 
 interface Props {
   setVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  fetchTravels: () => Promise<void>;
 }
 
-export default function TravelWrite({ setVisible }: Props) {
-  const { inputs, onChangeInputs, onClickSubmit, isValid } = useTravelWrite();
+export default function TravelWrite({ setVisible, fetchTravels }: Props) {
+  const { inputs, onChangeInputs, onClickSubmit, isValid } = useTravelWrite({
+    fetchTravels,
+  });
 
   return (
     <div className={styles.TravelWriteForm}>


### PR DESCRIPTION
## ✅ 기본 요구사항
### 공통
- [x] 완성된 `Day 34` 폴더를 활용하여 `Day 35` 폴더를 완성해 주세요.
- [x] 이미지 업로드를 위해 `apollo-upload-client` 라이브러리를 설치하고, `commons/settings/apollo-setting.tsx` 파일에 Apollo 클라이언트 설정을 완료해 주세요.
### 게시글 등록
- **이미지 첨부**
    - [x] 네모난 사각형 아이콘 3개를 만들어 이미지 등록 UI를 구성해 주세요.
    - [x] 아이콘 클릭 시 파일 선택 창이 열리고, 이미지를 선택하면 `uploadFile` GraphQL API를 사용해 파일이 서버에 자동 저장되도록 구현해요.
- **미리보기 기능**
    - [x] 업로드 완료 후, 해당 이미지가 클릭한 아이콘 자리에 미리보기로 보이도록 구현해 주세요.
- **유효성 검증**
    - [x] 업로드할 이미지 파일의 최대 용량을 **5MB**로 제한해야 합니다. 5MB를 초과하는 파일은 `alert` 창을 띄워 사용자에게 알려야 합니다.
- **게시글 전송**
    - [x] 이미지는 필수가 아니므로, 이미지를 첨부하지 않아도 게시글 등록이 가능해야 합니다.
    - [x] `[게시글 등록하기]` 버튼 클릭 시, `createBoard` GraphQL API를 호출하여 이미지 주소 문자열을 배열(`[]`)에 담아 게시글 데이터와 함께 서버에 전송해요.
- **이미지 삭제**
    - [x] 미리보기 이미지에 마우스를 올리면 삭제 버튼이 나타나고, 이 버튼을 클릭하면 미리보기 이미지가 사라지도록 구현해요.
### 게시글 수정
- **기존 이미지 불러오기**
    - [x] 게시글 수정 페이지에 접속하면, `fetchBoard` GraphQL API를 사용해 기존에 등록되어 있던 이미지를 불러와야 합니다.
- **미리보기 표시**
    - [x] 불러온 이미지의 개수와 순서에 맞게 미리보기를 그려주세요.
    - [x] 이미지가 없는 자리는 기존의 네모난 사각형 아이콘이 보이도록 구현해요.
- **이미지 변경 로직**
    - [x] 미리보기 이미지를 클릭하여 새로운 이미지로 변경할 수 있도록 만듭니다. 이 과정은 등록 페이지와 동일하게 `uploadFile` API를 사용하여 이미지를 자동 저장해요.
- **게시글 전송**
    - [x] `[게시글 수정하기]` 버튼 클릭 시, `updateBoard` GraphQL API를 호출하여 수정된 이미지 주소 문자열 배열을 게시글 데이터와 함께 서버에 전송해요.
### 게시글 상세
- **이미지 조회**
    - [x] `fetchBoard` GraphQL API를 사용해 게시글을 조회할 때 이미지를 함께 불러와요.
- **이미지 표시**
    - [x] 게시글 내용 위에 이미지를 배치하고, 이미지가 여러 개일 경우 1개씩 세로로 나열하여 보여줘요.
    - [x] 이미지가 없는 게시글은 이미지를 보여주지 않아요.
### 컴포넌트 리팩토링
- **타입스크립트 적용**
    - [x] 게시글 등록, 수정, 상세 페이지 컴포넌트 파일에 발생하는 모든 **타입 에러**를 해결해 주세요.
- **파일 분리**
    - [x] 유지보수가 쉽도록 아래 규칙에 맞춰 컴포넌트 파일을 분리해 주세요.
        - `hooks.ts`
        - `index.tsx`
        - `queries.ts`
        - `styles.ts`
        - `types.ts`
___
## 🧪 상세 구현 내용
- 기존 구현하였던 이미지 업로드에서 리팩토링 진행
  - 기존 코드에서 이미지 배열에 map을 활용하여 코드 간소화
  - 이미지 호버 시 삭제 버튼 추가
  - 유효성 검증 추가