### PR TITLE
[250923] Day35 - 과제제출

### DIFF
--- a/03_trip-trip/03_cna-v2/package.json
+++ b/03_trip-trip/03_cna-v2/package.json
@@ -18,12 +18,11 @@
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "@supabase/supabase-js": "^2.57.4",
-    "@types/apollo-upload-client": "17.0.0",
     "@types/node": "22.5.4",
     "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
     "antd": "^5.27.3",
-    "apollo-upload-client": "17.0.0",
+    "apollo-upload-client": "18.0.1",
     "autoprefixer": "10.4.20",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.8",
@@ -43,6 +42,7 @@
   "devDependencies": {
     "@graphql-codegen/cli": "6.0.0",
     "@graphql-codegen/client-preset": "5.0.0",
+    "@types/apollo-upload-client": "^18.0.0",
     "typescript": "5.5.4"
   }
 }

--- a/03_trip-trip/03_cna-v2/pnpm-lock.yaml
+++ b/03_trip-trip/03_cna-v2/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.57.4
         version: 2.57.4
-      '@types/apollo-upload-client':
-        specifier: 17.0.0
-        version: 17.0.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: 22.5.4
         version: 22.5.4
@@ -48,8 +45,8 @@ importers:
         specifier: ^5.27.3
         version: 5.27.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       apollo-upload-client:
-        specifier: 17.0.0
-        version: 17.0.0(@apollo/client@3.14.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.11.0)
+        specifier: 18.0.1
+        version: 18.0.1(@apollo/client@3.14.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.11.0)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.4.45)
@@ -102,6 +99,9 @@ importers:
       '@graphql-codegen/client-preset':
         specifier: 5.0.0
         version: 5.0.0(graphql@16.11.0)
+      '@types/apollo-upload-client':
+        specifier: ^18.0.0
+        version: 18.0.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -1084,8 +1084,8 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/apollo-upload-client@17.0.0':
-    resolution: {integrity: sha512-S1HUj9g+wn0fM29vLsnD87hTW2h2k/ELlTTJ+mUHTnF6oxmm46KkqxrzFPR7u2rQBjjSiKQEaXLqBn76s8bzBg==}
+  '@types/apollo-upload-client@18.0.0':
+    resolution: {integrity: sha512-cMgITNemktxasqvp6jiPj15dv84n3FTMvMoYBP1+xonDS+0l6JygIJrj2LJh85rShRzTOOkrElrAsCXXARa3KA==}
 
   '@types/extract-files@13.0.1':
     resolution: {integrity: sha512-/fRbzc2lAd7jDJSSnxWiUyXWjdUZZ4HbISLJzVgt1AvrdOa7U49YRPcvuCUywkmURZ7uwJOheDjx19itbQ5KvA==}
@@ -1362,11 +1362,11 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  apollo-upload-client@17.0.0:
-    resolution: {integrity: sha512-pue33bWVbdlXAGFPkgz53TTmxVMrKeQr0mdRcftNY+PoHIdbGZD0hoaXHvO6OePJAkFz7OiCFUf98p1G/9+Ykw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >= 16.0.0}
+  apollo-upload-client@18.0.1:
+    resolution: {integrity: sha512-OQvZg1rK05VNI79D658FUmMdoI2oB/KJKb6QGMa2Si25QXOaAvLMBFUEwJct7wf+19U8vk9ILhidBOU1ZWv6QA==}
+    engines: {node: ^18.15.0 || >=20.4.0}
     peerDependencies:
-      '@apollo/client': ^3.0.0
+      '@apollo/client': ^3.8.0
       graphql: 14 - 16
 
   arg@5.0.2:
@@ -1949,9 +1949,9 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
-  extract-files@11.0.0:
-    resolution: {integrity: sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==}
-    engines: {node: ^12.20 || >= 14.13}
+  extract-files@13.0.0:
+    resolution: {integrity: sha512-FXD+2Tsr8Iqtm3QZy1Zmwscca7Jx3mMC5Crr+sEP1I303Jy1CYMuYCm7hRTplFNg3XdUavErkxnTzpaqdSoi6g==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2345,6 +2345,10 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -5041,7 +5045,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/apollo-upload-client@17.0.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@types/apollo-upload-client@18.0.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@apollo/client': 3.14.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/extract-files': 13.0.1
@@ -5369,10 +5373,10 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  apollo-upload-client@17.0.0(@apollo/client@3.14.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.11.0):
+  apollo-upload-client@18.0.1(@apollo/client@3.14.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.11.0):
     dependencies:
       '@apollo/client': 3.14.0(@types/react@18.3.5)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      extract-files: 11.0.0
+      extract-files: 13.0.0
       graphql: 16.11.0
 
   arg@5.0.2: {}
@@ -6156,7 +6160,9 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
-  extract-files@11.0.0: {}
+  extract-files@13.0.0:
+    dependencies:
+      is-plain-obj: 4.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -6574,6 +6580,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:

--- a/03_trip-trip/03_cna-v2/src/app/boards/styles.module.css
+++ b/03_trip-trip/03_cna-v2/src/app/boards/styles.module.css
@@ -1,6 +1,6 @@
 .detailLayout {
   display: flex;
-  width: 1920px;
+  width: 100%;
   padding: 40px 0px;
   flex-direction: column;
   align-items: center;

--- a/03_trip-trip/03_cna-v2/src/app/boards/styles.module.css
+++ b/03_trip-trip/03_cna-v2/src/app/boards/styles.module.css
@@ -23,7 +23,5 @@
   gap: 24px;
   padding: 24px 48px;
   border-radius: 16px;
-  /* background: #fff; */
-
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.08);
 }

--- a/03_trip-trip/03_cna-v2/src/commons/libraries/validation/image-validation.ts
+++ b/03_trip-trip/03_cna-v2/src/commons/libraries/validation/image-validation.ts
@@ -1,0 +1,23 @@
+export const checkValidationFile = (file: File) => {
+  if (typeof file === 'undefined') {
+    alert('파일이 없습니다.')
+    return false
+  }
+
+  if (file.size > 5 * 1024 * 1024) {
+    alert('파일 용량이 너무 큽니다.(제한: 5MB)')
+    return false
+  }
+
+  if (
+    !file.type.includes('jpeg') &&
+    !file.type.includes('jpg') &&
+    !file.type.includes('png') &&
+    !file.type.includes('webp') &&
+    !file.type.includes('svg')
+  ) {
+    alert('jp(e)g, png, webp, svg 파일만 업로드 가능합니다.')
+    return false
+  }
+  return true
+}

--- a/03_trip-trip/03_cna-v2/src/commons/settings/apollo-setting.tsx
+++ b/03_trip-trip/03_cna-v2/src/commons/settings/apollo-setting.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ApolloClient, ApolloLink, ApolloProvider, InMemoryCache } from '@apollo/client'
-import { createUploadLink } from 'apollo-upload-client'
+import createUploadLink from 'apollo-upload-client/createUploadLink.mjs'
 interface IApolloSetting {
   children: React.ReactNode
 }

--- a/03_trip-trip/03_cna-v2/src/components/boards-detail/detail/index.tsx
+++ b/03_trip-trip/03_cna-v2/src/components/boards-detail/detail/index.tsx
@@ -6,7 +6,6 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import styles from './styles.module.css'
 import profileImage from '@assets/profile_image.png'
-import cheongsanImage from '@assets/cheongsan.png'
 import {
   FetchBoardDocument,
   FetchBoardQuery,
@@ -27,10 +26,6 @@ const IMAGE_SRC = {
   profileImage: {
     src: profileImage,
     alt: '프로필이미지',
-  },
-  cheongsanImage: {
-    src: cheongsanImage,
-    alt: '청산사진',
   },
 } as const
 
@@ -76,11 +71,24 @@ export default function BoardDetailPage() {
         </Tooltip>
       </div>
       <div className={styles.detailContentContainer}>
-        <Image
-          src={IMAGE_SRC.cheongsanImage.src}
-          alt={IMAGE_SRC.cheongsanImage.alt}
-          className={styles.detailContentImage}
-        />
+        {data?.fetchBoard?.images &&
+          data?.fetchBoard?.images?.map((image, idx) => {
+            const isUrl = image !== ''
+            return (
+              <div key={idx}>
+                {isUrl && (
+                  <Image
+                    src={`https://storage.googleapis.com/${image}`}
+                    alt={'불러온 사진'}
+                    width={400}
+                    height={0}
+                    className={styles.detailContentImage}
+                  />
+                )}
+              </div>
+            )
+          })}
+
         <div className={styles.detailContentText}>{data?.fetchBoard?.contents}</div>
         {data?.fetchBoard?.youtubeUrl && (
           <div className={styles.youtube}>

--- a/03_trip-trip/03_cna-v2/src/components/boards-detail/detail/styles.module.css
+++ b/03_trip-trip/03_cna-v2/src/components/boards-detail/detail/styles.module.css
@@ -57,6 +57,7 @@
   width: 100%;
   flex-direction: column;
 }
+
 .detailContentText {
   color: #000;
   font-size: 16px;
@@ -79,10 +80,13 @@
 }
 
 .detailContentImage {
-  width: 480px;
-  height: 531px;
+  width: 400px;
+  object-fit: cover;
+  height: auto;
 }
 
+.detailContentContainer img {
+}
 .detailContentGoodOrBad {
   display: flex;
   justify-content: center;

--- a/03_trip-trip/03_cna-v2/src/components/boards-write/hook.ts
+++ b/03_trip-trip/03_cna-v2/src/components/boards-write/hook.ts
@@ -43,6 +43,7 @@ export default function useBoardForm(props: BoardFormProps) {
     title: data?.fetchBoard?.title ?? '',
     content: data?.fetchBoard?.contents ?? '',
     link: data?.fetchBoard?.youtubeUrl ?? '',
+    images: data?.fetchBoard?.images ?? ['', '', ''],
   })
   // 주소 input
   const [address, setAddress] = useState({
@@ -101,6 +102,15 @@ export default function useBoardForm(props: BoardFormProps) {
     })
   }
 
+  // image index에 일치하게 업로드
+  const setImageByIndex = (idx: number, url: string) => {
+    setBoardValue((prev) => {
+      const next = { ...prev, images: [...prev.images] }
+      next.images[idx] = url
+      return next
+    })
+  }
+
   const onClickSignup = async () => {
     //새글 등록하기일 경우
     if (props.isEdit === false) {
@@ -145,7 +155,7 @@ export default function useBoardForm(props: BoardFormProps) {
                 address: address.base,
                 addressDetail: address.detail,
               },
-              images: ['', ''],
+              images: boardValue.images,
             },
           },
         })
@@ -180,8 +190,8 @@ export default function useBoardForm(props: BoardFormProps) {
       }
 
       // 비밀번호 확인하기
-
       const 입력받은비밀번호 = prompt('글을 작성할때 입력하셨던 비밀번호를 입력해주세요')
+
       const updateInput: any = {}
       if (boardValue.title?.trim() && boardValue.title !== data?.fetchBoard?.title) {
         updateInput.title = boardValue.title
@@ -193,6 +203,10 @@ export default function useBoardForm(props: BoardFormProps) {
 
       if (boardValue.link !== data?.fetchBoard?.youtubeUrl) {
         updateInput.youtubeUrl = boardValue.link
+      }
+
+      if (boardValue.images !== data?.fetchBoard.images) {
+        updateInput.images = boardValue.images
       }
 
       const boardAddress: any = {}
@@ -258,8 +272,8 @@ export default function useBoardForm(props: BoardFormProps) {
     onChangeValue,
     onChangeAddress,
     onClickSignup,
+    setImageByIndex,
     isButtonDisabled,
-    data,
     boardValue,
     address,
     boardError,

--- a/03_trip-trip/03_cna-v2/src/components/boards-write/index.tsx
+++ b/03_trip-trip/03_cna-v2/src/components/boards-write/index.tsx
@@ -6,6 +6,15 @@ import { IBoardWriteProps } from './types'
 import useBoardForm from './hook'
 import { Modal } from 'antd'
 import DaumPostcodeEmbed from 'react-daum-postcode'
+import { useRef } from 'react'
+import { useMutation } from '@apollo/client'
+import {
+  UploadFileDocument,
+  UploadFileMutation,
+  UploadFileMutationVariables,
+} from 'commons/graphql/graphql'
+import { checkValidationFile } from 'commons/libraries/validation/image-validation'
+import CloseIcon from '@mui/icons-material/Close'
 
 const IMAGE_SRC = {
   addImage: {
@@ -19,8 +28,8 @@ export default function BoardWritePage(props: IBoardWriteProps) {
     onChangeValue,
     onChangeAddress,
     onClickSignup,
+    setImageByIndex,
     isButtonDisabled,
-    data,
     boardValue,
     address,
     boardError,
@@ -29,6 +38,31 @@ export default function BoardWritePage(props: IBoardWriteProps) {
     handleComplete,
   } = useBoardForm({ isEdit: props.isEdit })
 
+  const fileRefs = [useRef(null), useRef(null), useRef(null)]
+
+  const onClickImagebyIdx = (idx: number) => {
+    fileRefs[idx].current?.click()
+  }
+
+  const [uploadFile] = useMutation<UploadFileMutation, UploadFileMutationVariables>(
+    UploadFileDocument
+  )
+
+  const onChangeFile = async (event, idx: number) => {
+    const file = event.target.files?.[0]
+
+    const isValid = checkValidationFile(file)
+    if (!isValid) return
+
+    const { data } = await uploadFile({ variables: { file } })
+    const url = data?.uploadFile?.url ?? ''
+
+    setImageByIndex(idx, url)
+  }
+
+  const onClickDelete = (idx: number) => {
+    setImageByIndex(idx, '')
+  }
   return (
     <div className={styles.layout}>
       {/* title */}
@@ -48,7 +82,7 @@ export default function BoardWritePage(props: IBoardWriteProps) {
               </div>
               <input
                 disabled={props.isEdit}
-                value={data?.fetchBoard?.writer ?? boardValue.name}
+                value={boardValue.name}
                 type="text"
                 id="name"
                 placeholder="작성자 명을 입력해 주세요."
@@ -170,9 +204,35 @@ export default function BoardWritePage(props: IBoardWriteProps) {
         <div className={styles.enroll_row_section}>
           <div>사진 첨부</div>
           <div className={styles.picture_enroll_row}>
-            <Image src={IMAGE_SRC.addImage.src} alt="이미지추가" />
-            <Image src={IMAGE_SRC.addImage.src} alt="이미지추가" />
-            <Image src={IMAGE_SRC.addImage.src} alt="이미지추가" />
+            {[0, 1, 2].map((_, idx) => {
+              const url = boardValue.images[idx]
+              const hasUrl = !!url
+              const src = hasUrl ? `https://storage.googleapis.com/${url}` : IMAGE_SRC.addImage.src
+              return (
+                <div key={idx} className={styles.uploadImageWrapper}>
+                  {hasUrl && (
+                    <button className={styles.closeButton} onClick={(e) => onClickDelete(e, idx)}>
+                      <CloseIcon />
+                    </button>
+                  )}
+                  <Image
+                    src={src}
+                    alt="이미지추가"
+                    onClick={() => onClickImagebyIdx(idx)}
+                    width={160}
+                    height={0}
+                    className={styles.uploadImage}
+                  />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    style={{ display: 'none' }}
+                    ref={fileRefs[idx]}
+                    onChange={(e) => onChangeFile(e, idx)}
+                  />
+                </div>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/03_trip-trip/03_cna-v2/src/components/boards-write/index.tsx
+++ b/03_trip-trip/03_cna-v2/src/components/boards-write/index.tsx
@@ -211,7 +211,7 @@ export default function BoardWritePage(props: IBoardWriteProps) {
               return (
                 <div key={idx} className={styles.uploadImageWrapper}>
                   {hasUrl && (
-                    <button className={styles.closeButton} onClick={(e) => onClickDelete(e, idx)}>
+                    <button className={styles.closeButton} onClick={() => onClickDelete(idx)}>
                       <CloseIcon />
                     </button>
                   )}

--- a/03_trip-trip/03_cna-v2/src/components/boards-write/styles.module.css
+++ b/03_trip-trip/03_cna-v2/src/components/boards-write/styles.module.css
@@ -185,3 +185,32 @@
   background-color: #c7c7c7;
   color: #e4e4e4;
 }
+
+.uploadImageWrapper {
+  position: relative;
+}
+
+.uploadImageWrapper:has(:hover) .closeButton {
+  display: block;
+}
+
+.closeButton {
+  display: none;
+  position: absolute;
+  top: 9px;
+  right: 9px;
+  padding: 3.77px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 50%;
+}
+
+.closeButton svg {
+  color: #fff;
+  size: 16px;
+}
+
+.uploadImage {
+  width: 160px;
+  height: 160px;
+  border-radius: 8px;
+}


### PR DESCRIPTION
# 필수과제(Day35)
## 요구사항(03_cna-v1 : X , 03_cna-v2 : 🔺)
### 공통
- [x] 완성된 `Day 34` 폴더를 활용하여 `Day 35` 폴더를 완성해 주세요.
- [x]  이미지 업로드를 위해 `apollo-upload-client` 라이브러리를 설치하고, `commons/settings/apollo-setting.tsx` 파일에 Apollo 클라이언트 설정을 완료해 주세요.

### 게시글 등록

- **이미지 첨부**
    - [x]  네모난 사각형 아이콘 3개를 만들어 이미지 등록 UI를 구성해 주세요.
    - [x]  아이콘 클릭 시 파일 선택 창이 열리고, 이미지를 선택하면 `uploadFile` GraphQL API를 사용해 파일이 서버에 자동 저장되도록 구현해요.
- **미리보기 기능**
    - [x]  업로드 완료 후, 해당 이미지가 클릭한 아이콘 자리에 미리보기로 보이도록 구현해 주세요.
- **유효성 검증**
    - [x]  업로드할 이미지 파일의 최대 용량을 **5MB**로 제한해야 합니다. 5MB를 초과하는 파일은 `alert` 창을 띄워 사용자에게 알려야 합니다.
- **게시글 전송**
    - [x]  이미지는 필수가 아니므로, 이미지를 첨부하지 않아도 게시글 등록이 가능해야 합니다.
    - [x]  `[게시글 등록하기]` 버튼 클릭 시, `createBoard` GraphQL API를 호출하여 이미지 주소 문자열을 배열(`[]`)에 담아 게시글 데이터와 함께 서버에 전송해요.
- **이미지 삭제**
    - [x]  미리보기 이미지에 마우스를 올리면 삭제 버튼이 나타나고, 이 버튼을 클릭하면 미리보기 이미지가 사라지도록 구현해요.

### 게시글 수정

- **기존 이미지 불러오기**
    - [x]  게시글 수정 페이지에 접속하면, `fetchBoard` GraphQL API를 사용해 기존에 등록되어 있던 이미지를 불러와야 합니다.
- **미리보기 표시**
    - [x]  불러온 이미지의 개수와 순서에 맞게 미리보기를 그려주세요.
    - [x]  이미지가 없는 자리는 기존의 네모난 사각형 아이콘이 보이도록 구현해요.
- **이미지 변경 로직**
    - [x]  미리보기 이미지를 클릭하여 새로운 이미지로 변경할 수 있도록 만듭니다. 이 과정은 등록 페이지와 동일하게 `uploadFile` API를 사용하여 이미지를 자동 저장해요.
- **게시글 전송**
    - [x]  `[게시글 수정하기]` 버튼 클릭 시, `updateBoard` GraphQL API를 호출하여 수정된 이미지 주소 문자열 배열을 게시글 데이터와 함께 서버에 전송해요.

### 게시글 상세

- **이미지 조회**
    - [x]  `fetchBoard` GraphQL API를 사용해 게시글을 조회할 때 이미지를 함께 불러와요.
- **이미지 표시**
    - [x]  게시글 내용 위에 이미지를 배치하고, 이미지가 여러 개일 경우 1개씩 세로로 나열하여 보여줘요.
    - [x]  이미지가 없는 게시글은 이미지를 보여주지 않아요.

### 컴포넌트 리팩토링

- **타입스크립트 적용**
    - [ ]  게시글 등록, 수정, 상세 페이지 컴포넌트 파일에 발생하는 모든 **타입 에러**를 해결해 주세요.
- **파일 분리**
    - [ ]  유지보수가 쉽도록 아래 규칙에 맞춰 컴포넌트 파일을 분리해 주세요.
        - `hooks.ts`
        - `index.tsx`
        - `queries.ts`
        - `styles.ts`
        - `types.ts`