### PR TITLE
[250923] Day35 - 과제제출

### DIFF
--- a/board/day27/package.json
+++ b/board/day27/package.json
@@ -15,6 +15,7 @@
     "@apollo/server": "^5.0.0",
     "@supabase/supabase-js": "^2.57.4",
     "antd": "^5.27.3",
+    "apollo-upload-client": "^18.0.1",
     "graphql": "^16.11.0",
     "next": "14.2.32",
     "react": "^18",

--- a/board/day27/pnpm-lock.yaml
+++ b/board/day27/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       antd:
         specifier: ^5.27.3
         version: 5.27.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      apollo-upload-client:
+        specifier: ^18.0.1
+        version: 18.0.1(@apollo/client@3.11.10(@types/react@18.3.24)(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.11.0)
       graphql:
         specifier: ^16.11.0
         version: 16.11.0
@@ -1232,6 +1235,13 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apollo-upload-client@18.0.1:
+    resolution: {integrity: sha512-OQvZg1rK05VNI79D658FUmMdoI2oB/KJKb6QGMa2Si25QXOaAvLMBFUEwJct7wf+19U8vk9ILhidBOU1ZWv6QA==}
+    engines: {node: ^18.15.0 || >=20.4.0}
+    peerDependencies:
+      '@apollo/client': ^3.8.0
+      graphql: 14 - 16
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -1779,6 +1789,10 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  extract-files@13.0.0:
+    resolution: {integrity: sha512-FXD+2Tsr8Iqtm3QZy1Zmwscca7Jx3mMC5Crr+sEP1I303Jy1CYMuYCm7hRTplFNg3XdUavErkxnTzpaqdSoi6g==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2158,6 +2172,10 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -5056,6 +5074,12 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  apollo-upload-client@18.0.1(@apollo/client@3.11.10(@types/react@18.3.24)(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.11.0):
+    dependencies:
+      '@apollo/client': 3.11.10(@types/react@18.3.24)(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      extract-files: 13.0.0
+      graphql: 16.11.0
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -5788,6 +5812,10 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  extract-files@13.0.0:
+    dependencies:
+      is-plain-obj: 4.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -6200,6 +6228,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:

--- a/board/day27/src/commons/settings/apollo-setting.tsx
+++ b/board/day27/src/commons/settings/apollo-setting.tsx
@@ -1,11 +1,21 @@
 "use client"
 
-import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client'
+import { ApolloClient, ApolloLink, ApolloProvider, InMemoryCache } from '@apollo/client'
+import createUploadLink from 'apollo-upload-client/createUploadLink.mjs'
+
+// const client = new ApolloClient({
+//     uri: "http://main-practice.codebootcamp.co.kr/graphql",
+//     cache: new InMemoryCache()
+// })
+
+const uploadLink = createUploadLink({
+    uri: "http://main-practice.codebootcamp.co.kr/graphql",
+});
 
 const client = new ApolloClient({
-    uri: "http://main-practice.codebootcamp.co.kr/graphql",
-    cache: new InMemoryCache()
-})
+    link: ApolloLink.from([uploadLink]),
+    cache: new InMemoryCache(),
+});
 
 export default function ApolloSetting({children}) {
 

--- a/board/day27/src/commons/validation-file.ts
+++ b/board/day27/src/commons/validation-file.ts
@@ -1,0 +1,14 @@
+export const checkVaildationFile = (file: File) => {
+    if(typeof file === "undefined"){
+        return false
+    }
+
+    if(file.size  > 5 * 1024 * 1024){
+        return false
+    }
+
+    if(!file.type.includes("jpeg") && !file.type.includes("png")){
+        return false
+    }
+    return true;
+}

--- a/board/day27/src/components/boards-detail/detail/index.tsx
+++ b/board/day27/src/components/boards-detail/detail/index.tsx
@@ -11,7 +11,7 @@ import { Button, Tooltip } from 'antd';
 
 
 export default function BoardsDetail() {
-    const { 
+    const {
         onClickMove,
         data,
         onClickdisLike,
@@ -45,7 +45,23 @@ export default function BoardsDetail() {
                     </div>
                 </div>
 
-                <img className={style.image__main} src="/assets/images/BeachsideSerenity 1.png" />
+                {/* {data?.fetchBoard.images && data.fetchBoard.images !== '' && (
+          <img
+            className={style.image__main}
+            src={`https://storage.googleapis.com/${data.fetchBoard.images}`}
+            alt="board image"
+          />
+        )} */}
+      {data?.fetchBoard.images && data.fetchBoard.images.length > 0 && (
+        data.fetchBoard.images.map((img: string, index: number) => (
+          <img
+            key={index}
+            className={style.image__main}
+            src={`https://storage.googleapis.com/${img}`}
+            alt="board image"
+          />
+        ))
+      )}
 
                 <div className={style.text}>
                     {data?.fetchBoard.contents}

--- a/board/day27/src/components/boards-write/index.tsx
+++ b/board/day27/src/components/boards-write/index.tsx
@@ -7,6 +7,7 @@ import DaumPostcodeEmbed from 'react-daum-postcode';
 
 
 import { IBoardsWriteProps } from "./types";
+import { ApolloClient } from "@apollo/client";
 
 export default function BoardsWrite(props:IBoardsWriteProps ) {
     const { 
@@ -29,8 +30,13 @@ export default function BoardsWrite(props:IBoardsWriteProps ) {
         detailAddress,
         onChangeDetailaddress,
         onChangeYoutube,
-        
+        onClickImage,
+        fileRef,
+        onChangeFile,
+        imageUrl,
+        onDeleteImage
 
+        
     } = useBoardsWrite()
 
     return (
@@ -90,18 +96,56 @@ export default function BoardsWrite(props:IBoardsWriteProps ) {
                 <div className={style.메인__1__1}>
                     <div>사진 첨부</div>
                     <div className={style.사진첨부목록}>
-                        <div className={style.사진첨부리스트}>
-                            <img src="../assets/icons/add.png"></img>
-                            <div>클릭해서 사진 업로드</div>
-                        </div>
-                        <div className={style.사진첨부리스트}>
-                            <img src="../assets/icons/add.png"></img>
-                            <div>클릭해서 사진 업로드</div>
-                        </div>
-                        <div className={style.사진첨부리스트}>
-                            <img src="../assets/icons/add.png"></img>
-                            <div>클릭해서 사진 업로드</div>
-                        </div>
+                      {Array.from({ length: 6 }).map((_, index) => {
+                        const currentImage =
+                          imageUrl[index] !== undefined && imageUrl[index] !== ""
+                            ? imageUrl[index]
+                            : props?.data?.fetchBoard?.images?.[index] ?? "";
+                        return (
+                          <div
+                            key={index}
+                            className={style.사진첨부리스트}
+                            style={{ position: "relative" }}
+                          >
+                            <input
+                              type="file"
+                              style={{ display: "none" }}
+                              ref={fileRef}
+                              onChange={(e) => onChangeFile(e, index)}
+                            />
+                            {currentImage && (
+                                                      <>
+                                                      <img
+                                                        src={`https://storage.googleapis.com/${currentImage}`}
+                                                        alt={`uploaded ${index}`}
+                                                      />
+                                                      <button
+                                                        type="button"
+                                                        onClick={(e) => {
+                                                          e.stopPropagation();
+                                                          onDeleteImage(index);
+                                                        }}
+                                                        style={{
+                                                          position: "absolute",
+                                                          right: "4px",
+                                                          bottom: "4px",
+                                                          background: "red",
+                                                          color: "white",
+                                                          border: "none",
+                                                          borderRadius: "50%",
+                                                          width: "20px",
+                                                          height: "20px",
+                                                          cursor: "pointer",
+                                                        }}
+                                                      >
+                                                        ×
+                                                      </button>
+                                                    </>
+                            )}
+                            <div onClick={() => onClickImage(index)}>클릭해서 사진 업로드</div>
+                          </div>
+                        );
+                      })}
                     </div>
                 </div>
             </div>

--- a/board/day27/src/components/boards-write/queries.ts
+++ b/board/day27/src/components/boards-write/queries.ts
@@ -1,18 +1,43 @@
 import { gql } from "@apollo/client";
 
 export const mygraphql = gql`
-mutation createBoard($writer: String!, $password: String!, $title: String!, $contents: String!, $youtubeUrl: String, $boardAddress: BoardAddressInput){
-    createBoard( createBoardInput:{writer: $writer, password: $password, title:$title, contents: $contents, youtubeUrl: $youtubeUrl , boardAddress: $boardAddress }){
+mutation createBoard($createBoardInput: CreateBoardInput!){
+    createBoard(createBoardInput: $createBoardInput){
         _id, title, contents, likeCount, dislikeCount
     }
 }
 `;
 
 export const mygraphUpdateql = gql`
-    mutation updateBoard($boardId: ID!, $password: String, $updateBoardInput: UpdateBoardInput!){
-        updateBoard(boardId: $boardId, password: $password, updateBoardInput: $updateBoardInput)
-    {
-        _id, title, writer, contents, address, addressDetail, zipcode, youtubeUrl
+mutation updateBoard(
+  $boardId: ID!,
+  $password: String,
+  $updateBoardInput: UpdateBoardInput!
+){
+  updateBoard(
+    boardId: $boardId,
+    password: $password,
+    updateBoardInput: $updateBoardInput
+  ) {
+    _id
+    title
+    writer
+    contents
+    youtubeUrl
+    images
+    boardAddress {
+      zipcode
+      address
+      addressDetail
     }
-    }
+  }
+}
 `;
+
+ export const UPLOAD_FILE=gql`
+   mutation  uploadFile($file: Upload!){
+        uploadFile(file:$file){
+            url
+        }
+    }
+`


### PR DESCRIPTION
# Day 35

## 과제 요구사항

### 공통

- [x]  완성된 `Day 34` 폴더를 활용하여 `Day 35` 폴더를 완성해 주세요.
- [x]  이미지 업로드를 위해 `apollo-upload-client` 라이브러리를 설치하고, `commons/settings/apollo-setting.tsx` 파일에 Apollo 클라이언트 설정을 완료해 주세요.

### 게시글 등록

- **이미지 첨부**
    - [ ]  네모난 사각형 아이콘 3개를 만들어 이미지 등록 UI를 구성해 주세요.
    - [x]  아이콘 클릭 시 파일 선택 창이 열리고, 이미지를 선택하면 `uploadFile` GraphQL API를 사용해 파일이 서버에 자동 저장되도록 구현해요.
- **미리보기 기능**
    - [x]  업로드 완료 후, 해당 이미지가 클릭한 아이콘 자리에 미리보기로 보이도록 구현해 주세요.
- **유효성 검증**
    - [x]  업로드할 이미지 파일의 최대 용량을 **5MB**로 제한해야 합니다. 5MB를 초과하는 파일은 `alert` 창을 띄워 사용자에게 알려야 합니다.
- **게시글 전송**
    - [x]  이미지는 필수가 아니므로, 이미지를 첨부하지 않아도 게시글 등록이 가능해야 합니다.
    - [x]  `[게시글 등록하기]` 버튼 클릭 시, `createBoard` GraphQL API를 호출하여 이미지 주소 문자열을 배열(`[]`)에 담아 게시글 데이터와 함께 서버에 전송해요.
- **이미지 삭제**
    - [ ]  미리보기 이미지에 마우스를 올리면 삭제 버튼이 나타나고, 이 버튼을 클릭하면 미리보기 이미지가 사라지도록 구현해요.

### 게시글 수정

- **기존 이미지 불러오기**
    - [ ]  게시글 수정 페이지에 접속하면, `fetchBoard` GraphQL API를 사용해 기존에 등록되어 있던 이미지를 불러와야 합니다.
- **미리보기 표시**
    - [x]  불러온 이미지의 개수와 순서에 맞게 미리보기를 그려주세요.
    - [x]  이미지가 없는 자리는 기존의 네모난 사각형 아이콘이 보이도록 구현해요.
- **이미지 변경 로직**
    - [ ]  미리보기 이미지를 클릭하여 새로운 이미지로 변경할 수 있도록 만듭니다. 이 과정은 등록 페이지와 동일하게 `uploadFile` API를 사용하여 이미지를 자동 저장해요.
- **게시글 전송**
    - [ ]  `[게시글 수정하기]` 버튼 클릭 시, `updateBoard` GraphQL API를 호출하여 수정된 이미지 주소 문자열 배열을 게시글 데이터와 함께 서버에 전송해요.

### 게시글 상세

- **이미지 조회**
    - [x]  `fetchBoard` GraphQL API를 사용해 게시글을 조회할 때 이미지를 함께 불러와요.
- **이미지 표시**
    - [x]  게시글 내용 위에 이미지를 배치하고, 이미지가 여러 개일 경우 1개씩 세로로 나열하여 보여줘요.
    - [ ]  이미지가 없는 게시글은 이미지를 보여주지 않아요.

### 컴포넌트 리팩토링

- **타입스크립트 적용**
    - [ ]  게시글 등록, 수정, 상세 페이지 컴포넌트 파일에 발생하는 모든 **타입 에러**를 해결해 주세요.
- **파일 분리**
    - [ ]  유지보수가 쉽도록 아래 규칙에 맞춰 컴포넌트 파일을 분리해 주세요.
        - `hooks.ts`
        - `index.tsx`
        - `queries.ts`
        - `styles.ts`
        - `types.ts`

아직 안되는 기능이 많고 어려워 금일 다시 공부예정입니다.